### PR TITLE
FIX: /transfer duplicates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inconnu"
-version = "2026.6.0"
+version = "2026.7.0"
 description = "An advanced Discord dice bot and character manager for V5"
 authors = [{ name = "tiltowait", email = "208040+tiltowait@users.noreply.github.com" }]
 license = "MIT"

--- a/src/inconnu/character/update/paramupdate.py
+++ b/src/inconnu/character/update/paramupdate.py
@@ -24,10 +24,8 @@ async def update_name(character: VChar, new_name: str) -> str:
         raise ValueError(f"{new_name} is already this character's name!")
     if character.raw_name.casefold() != new_name.casefold():
         # We want to let them rename a character to fix capitalization
-        all_chars = await services.char_mgr.fetchall(character.guild, character.user)
-        for char in all_chars:
-            if char.raw_name.casefold() == new_name.casefold():
-                raise ValueError(f"You already have a character named `{new_name}`!")
+        if await services.char_mgr.has_character(character.guild, character.user, new_name):
+            raise ValueError(f"You already have a character named `{new_name}`!")
 
     old_name = character.name
     character.name = new_name

--- a/src/inconnu/misc/__init__.py
+++ b/src/inconnu/misc/__init__.py
@@ -12,6 +12,7 @@ from inconnu.misc.remorse import remorse
 from inconnu.misc.rouse import rouse
 from inconnu.misc.slake import slake
 from inconnu.misc.stain import stain
+from inconnu.misc.transfer import transfer_character
 
 __all__ = (
     "aggheal",
@@ -22,6 +23,7 @@ __all__ = (
     "frenzy",
     "mend",
     "percentile",
+    "transfer_character",
     "remorse",
     "rouse",
     "show_changelog",

--- a/src/inconnu/misc/__init__.py
+++ b/src/inconnu/misc/__init__.py
@@ -23,10 +23,10 @@ __all__ = (
     "frenzy",
     "mend",
     "percentile",
-    "transfer_character",
     "remorse",
     "rouse",
     "show_changelog",
     "slake",
     "stain",
+    "transfer_character",
 )

--- a/src/inconnu/misc/transfer.py
+++ b/src/inconnu/misc/transfer.py
@@ -1,0 +1,45 @@
+"""Transfer character ownership."""
+
+
+import discord
+
+import errors
+import services
+import ui
+from ctx import AppCtx
+
+
+async def transfer_character(
+    ctx: AppCtx,
+    current_owner: discord.Member,
+    character: str,
+    new_owner: discord.Member,
+):
+    """Reassign a character from one player to another."""
+    if current_owner.id == new_owner.id:
+        await ui.embeds.error(ctx, "`current_owner` and `new_owner` can't be the same.")
+        return
+
+    try:
+        assert ctx.guild is not None  # Guild context guarantees this
+        xfer = await services.char_mgr.fetchone(ctx.guild, current_owner, character)
+
+        if ctx.guild.id == xfer.guild and current_owner.id == xfer.user:
+            current_mention = current_owner.mention
+            new_mention = new_owner.mention
+
+            try:
+                await services.char_mgr.transfer(xfer, current_owner, new_owner)
+                await ctx.respond(
+                    f"Transferred **{xfer.name}** from {current_mention} to {new_mention}."
+                )
+                await ctx.bot.transfer_premium(new_owner, xfer)
+            except errors.DuplicateCharacterError as err:
+                await ui.embeds.error(ctx, str(err))
+        else:
+            await ui.embeds.error(ctx, f"{current_owner.display_name} doesn't own {xfer.name}!")
+
+    except errors.CharacterNotFoundError:
+        await ui.embeds.error(ctx, "Character not found.")
+    except (LookupError, ValueError) as err:
+        await ui.embeds.error(ctx, err)

--- a/src/inconnu/misc/transfer.py
+++ b/src/inconnu/misc/transfer.py
@@ -1,6 +1,5 @@
 """Transfer character ownership."""
 
-
 import discord
 
 import errors

--- a/src/interface/misc.py
+++ b/src/interface/misc.py
@@ -1,6 +1,5 @@
 """interface/misc.py - Miscellaneous commands."""
 
-import asyncio
 from typing import TYPE_CHECKING
 
 import discord
@@ -9,9 +8,7 @@ from discord.commands import slash_command
 from discord.ext import commands
 
 import constants
-import errors
 import inconnu
-import services
 import ui
 from ctx import AppCtx
 from inconnu.options import char_option
@@ -79,31 +76,7 @@ class MiscCommands(commands.Cog):
         new_owner: discord.Member,
     ):
         """Reassign a character from one player to another."""
-        if current_owner.id == new_owner.id:
-            await ui.embeds.error(ctx, "`current_owner` and `new_owner` can't be the same.")
-            return
-
-        try:
-            assert ctx.guild is not None  # Guild context guarantees this
-            xfer = await services.char_mgr.fetchone(ctx.guild, current_owner, character)
-
-            if ctx.guild.id == xfer.guild and current_owner.id == xfer.user:
-                current_mention = current_owner.mention
-                new_mention = new_owner.mention
-
-                msg = f"Transferred **{xfer.name}** from {current_mention} to {new_mention}."
-                await asyncio.gather(
-                    services.char_mgr.transfer(xfer, current_owner, new_owner), ctx.respond(msg)
-                )
-                await self.bot.transfer_premium(new_owner, xfer)
-
-            else:
-                await ui.embeds.error(ctx, f"{current_owner.display_name} doesn't own {xfer.name}!")
-
-        except errors.CharacterNotFoundError:
-            await ui.embeds.error(ctx, "Character not found.")
-        except (LookupError, ValueError) as err:
-            await ui.embeds.error(ctx, err)
+        await inconnu.misc.transfer_character(ctx, current_owner, character, new_owner)
 
 
 def setup(bot: "InconnuBot"):

--- a/src/services/characters.py
+++ b/src/services/characters.py
@@ -11,7 +11,7 @@ from loguru import logger
 
 import errors
 from models.vchar import VChar
-from utils.text import pluralize
+from utils.text import clean_text, pluralize
 
 
 class CharacterManager:
@@ -129,48 +129,31 @@ class CharacterManager:
         chars = await self.fetchguild(guild_id)
         return len(chars)
 
-    async def exists(
+    async def has_character(
         self,
-        guild: discord.Guild,
-        user: discord.Member,
+        guild: discord.Guild | int,
+        player: discord.Member | int,
         name: str,
-        is_spc: bool,
     ) -> bool:
-        """Determine whether a user already has a named character."""
-        await self.initialize()
+        """Returns True if the player has a character by a given name."""
+        name = clean_text(name).casefold()
+        guild_id = guild.id if isinstance(guild, discord.Guild) else guild
+        player_id = player.id if isinstance(player, discord.Member) else player
 
-        if is_spc:
-            owner_id = VChar.SPC_OWNER
-        else:
-            owner_id = user.id
-
-        name = name.casefold()
-        for character in await self.fetchall(guild, owner_id):
-            if character.name.casefold() == name.casefold():
+        for char in await self.fetchall(guild_id, player_id):
+            if char.raw_name.casefold() == name:
                 return True
-
         return False
 
     async def register(self, character: VChar):
         """Insert the character into the database and the cache."""
         await self.initialize()
 
-        # Acquire global lock to prevent race conditions on shared data structures
         async with self._lock:
-            try:
-                duplicate = next(
-                    char
-                    for char in self._characters
-                    if char.user == character.user
-                    and char.guild == character.guild
-                    and char.name.casefold() == character.name.casefold()
-                )
+            if await self.has_character(character.guild, character.user, character.raw_name):
                 raise errors.DuplicateCharacterError(
-                    f"Character '{duplicate.name}' already exists for this user in this guild."
+                    f"Character '{character.name}' already exists for this user in this guild."
                 )
-            except StopIteration:
-                # No duplicate found
-                pass
 
             await character.insert()
             self._id_cache[character.id_str] = character
@@ -213,12 +196,10 @@ class CharacterManager:
                 raise errors.WrongGuild(
                     f"{new_owner.display_name} is not in the same server as {character.name}!"
                 )
-            for char in await self.fetchall(new_owner.guild, new_owner):
-                if char.raw_name.casefold() == character.raw_name.casefold():
-                    raise errors.DuplicateCharacterError(
-                        f"{new_owner.display_name} already has a character named "
-                        f"{character.raw_name}"
-                    )
+            if await self.has_character(new_owner.guild, new_owner, character.raw_name):
+                raise errors.DuplicateCharacterError(
+                    f"{new_owner.display_name} already has a character named {character.raw_name}"
+                )
 
             character.user = new_owner.id
             await character.save()

--- a/src/services/characters.py
+++ b/src/services/characters.py
@@ -144,6 +144,7 @@ class CharacterManager:
         else:
             owner_id = user.id
 
+        name = name.casefold()
         for character in await self.fetchall(guild, owner_id):
             if character.name.casefold() == name.casefold():
                 return True
@@ -212,6 +213,12 @@ class CharacterManager:
                 raise errors.WrongGuild(
                     f"{new_owner.display_name} is not in the same server as {character.name}!"
                 )
+            for char in await self.fetchall(new_owner.guild, new_owner):
+                if char.raw_name.casefold() == character.raw_name.casefold():
+                    raise errors.DuplicateCharacterError(
+                        f"{new_owner.display_name} already has a character named "
+                        f"{character.raw_name}"
+                    )
 
             character.user = new_owner.id
             await character.save()

--- a/tests/commands/misc/test_transfer.py
+++ b/tests/commands/misc/test_transfer.py
@@ -1,0 +1,164 @@
+"""Character transfer command tests."""
+
+from typing import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+import errors
+import services
+from bot import InconnuBot
+from ctx import AppCtx
+from inconnu.misc.transfer import transfer_character
+from models.vchar import VChar
+
+
+def make_member(member_id: int, name: str) -> discord.Member:
+    """Create a Member mock."""
+    member = MagicMock(spec=discord.Member)
+    member.configure_mock(id=member_id, display_name=name, mention=f"<@{member_id}>")
+    return member
+
+
+@pytest.fixture
+def current_owner() -> discord.Member:
+    """The character's current owner (ID matches the char fixture's user)."""
+    return make_member(0, "Current")
+
+
+@pytest.fixture
+def new_owner() -> discord.Member:
+    """The transfer recipient."""
+    return make_member(1, "Recipient")
+
+
+@pytest.fixture
+async def mock_fetchone(char: VChar) -> AsyncGenerator[AsyncMock, None]:
+    """char_mgr.fetchone(), patched to return the char fixture."""
+    with patch.object(services.char_mgr, "fetchone", new_callable=AsyncMock) as mock:
+        mock.return_value = char
+        yield mock
+
+
+@pytest.fixture
+async def mock_transfer() -> AsyncGenerator[AsyncMock, None]:
+    """char_mgr.transfer(), patched."""
+    with patch.object(services.char_mgr, "transfer", new_callable=AsyncMock) as mock:
+        yield mock
+
+
+@pytest.fixture
+async def mock_transfer_premium(bot: InconnuBot) -> AsyncGenerator[AsyncMock, None]:
+    """InconnuBot.transfer_premium(), patched on the test bot instance."""
+    with patch.object(bot, "transfer_premium", new_callable=AsyncMock) as mock:
+        yield mock
+
+
+@pytest.fixture
+async def mock_error() -> AsyncGenerator[AsyncMock, None]:
+    """ui.embeds.error(), patched."""
+    with patch("ui.embeds.error", new_callable=AsyncMock) as mock:
+        yield mock
+
+
+async def test_transfer_same_owner_rejected(
+    ctx: AppCtx,
+    current_owner: discord.Member,
+    mock_fetchone: AsyncMock,
+    mock_error: AsyncMock,
+):
+    """Transferring a character to its current owner fails before any lookup."""
+    await transfer_character(ctx, current_owner, "Nadea Theron", current_owner)
+
+    mock_error.assert_awaited_once()
+    assert "can't be the same" in str(mock_error.await_args.args[1])
+    mock_fetchone.assert_not_awaited()
+
+
+async def test_transfer_success(
+    ctx: AppCtx,
+    char: VChar,
+    current_owner: discord.Member,
+    new_owner: discord.Member,
+    mock_fetchone: AsyncMock,
+    mock_transfer: AsyncMock,
+    mock_transfer_premium: AsyncMock,
+    mock_respond: AsyncMock,
+):
+    """A valid transfer updates ownership, responds, and checks premium status."""
+    await transfer_character(ctx, current_owner, char.name, new_owner)
+
+    mock_transfer.assert_awaited_once_with(char, current_owner, new_owner)
+
+    mock_respond.assert_awaited_once()
+    message = mock_respond.await_args.args[0]
+    assert char.name in message
+    assert current_owner.mention in message
+    assert new_owner.mention in message
+
+    mock_transfer_premium.assert_awaited_once_with(new_owner, char)
+
+
+async def test_transfer_duplicate_name_rejected(
+    ctx: AppCtx,
+    char: VChar,
+    current_owner: discord.Member,
+    new_owner: discord.Member,
+    mock_fetchone: AsyncMock,
+    mock_transfer: AsyncMock,
+    mock_transfer_premium: AsyncMock,
+    mock_respond: AsyncMock,
+    mock_error: AsyncMock,
+):
+    """A DuplicateCharacterError from the manager is shown as an error embed."""
+    mock_transfer.side_effect = errors.DuplicateCharacterError(
+        f"{new_owner.display_name} already has a character named {char.name}"
+    )
+
+    await transfer_character(ctx, current_owner, char.name, new_owner)
+
+    mock_error.assert_awaited_once()
+    assert "already has a character named" in str(mock_error.await_args.args[1])
+    mock_respond.assert_not_awaited()
+    mock_transfer_premium.assert_not_awaited()
+
+
+async def test_transfer_character_not_found(
+    ctx: AppCtx,
+    current_owner: discord.Member,
+    new_owner: discord.Member,
+    mock_fetchone: AsyncMock,
+    mock_transfer: AsyncMock,
+    mock_error: AsyncMock,
+):
+    """An unknown character name produces a not-found error."""
+    mock_fetchone.side_effect = errors.CharacterNotFoundError("nope")
+
+    await transfer_character(ctx, current_owner, "Jimmy Maxwell", new_owner)
+
+    mock_error.assert_awaited_once()
+    assert "Character not found." in str(mock_error.await_args.args[1])
+    mock_transfer.assert_not_awaited()
+
+
+@pytest.mark.parametrize("attr,value", [("user", 42), ("guild", 42)])
+async def test_transfer_ownership_mismatch(
+    attr: str,
+    value: int,
+    ctx: AppCtx,
+    char: VChar,
+    current_owner: discord.Member,
+    new_owner: discord.Member,
+    mock_fetchone: AsyncMock,
+    mock_transfer: AsyncMock,
+    mock_error: AsyncMock,
+):
+    """A guild or owner mismatch on the fetched character blocks the transfer."""
+    setattr(char, attr, value)
+
+    await transfer_character(ctx, current_owner, char.name, new_owner)
+
+    mock_error.assert_awaited_once()
+    assert "doesn't own" in str(mock_error.await_args.args[1])
+    mock_transfer.assert_not_awaited()

--- a/tests/services/test_character_manager.py
+++ b/tests/services/test_character_manager.py
@@ -647,32 +647,43 @@ async def test_transfer_duplicate_name_other_guild_allowed(
     assert char.user == u12.id
 
 
-async def test_exists(
+@pytest.mark.parametrize(
+    "name",
+    ["Nadea Theron", "nadea theron", "NADEA THERON", "  Nadea   Theron  "],
+)
+async def test_has_character(
+    name: str,
+    mgrf: CharacterManager,
+    g1: Guild,
+    u11: Member,
+):
+    """has_character() matches case-insensitively and ignores extra whitespace."""
+    assert await mgrf.has_character(g1, u11, name)
+
+
+async def test_has_character_accepts_ids(mgrf: CharacterManager, g1: Guild, u11: Member):
+    """has_character() accepts raw guild and player IDs."""
+    assert await mgrf.has_character(g1.id, u11.id, "Nadea Theron")
+
+
+async def test_has_character_no_match(
     mgrf: CharacterManager,
     g1: Guild,
     g2: Guild,
     u11: Member,
     u12: Member,
-    c111: VChar,
-    spc11: VChar,
+    u21: Member,
 ):
-    exists = await mgrf.exists(g1, u11, c111.name, False)
-    assert exists
+    """has_character() is False for unknown names and other users/guilds."""
+    assert not await mgrf.has_character(g1, u11, "Sabrina Malenkova")
+    assert not await mgrf.has_character(g1, u12, "Nadea Theron")
+    assert not await mgrf.has_character(g2, u21, "Nadea Theron")
 
-    exists = await mgrf.exists(g1, u11, c111.name, True)
-    assert not exists
 
-    exists = await mgrf.exists(g1, u12, c111.name, False)
-    assert not exists
-
-    exists = await mgrf.exists(g2, u11, c111.name, False)
-    assert not exists
-
-    exists = await mgrf.exists(g1, u11, spc11.name, True)
-    assert exists
-
-    exists = await mgrf.exists(g1, u11, spc11.name, False)
-    assert not exists
+async def test_has_character_spc(mgrf: CharacterManager, g1: Guild, spc11: VChar):
+    """SPC ownership checks work via has_character() with SPC_OWNER."""
+    assert await mgrf.has_character(g1, VChar.SPC_OWNER, spc11.raw_name)
+    assert not await mgrf.has_character(g1, 1, spc11.raw_name)
 
 
 async def test_fetchone_admin(

--- a/tests/services/test_character_manager.py
+++ b/tests/services/test_character_manager.py
@@ -599,6 +599,54 @@ async def test_transfer_wrong_guild(mgrf: CharacterManager, u11: Member, u21: Me
         mock_save.assert_not_awaited()
 
 
+@pytest.mark.parametrize("transform", [str, str.upper, str.lower])
+async def test_transfer_duplicate_name(
+    transform,
+    mgrf: CharacterManager,
+    g1: Guild,
+    u11: Member,
+    u12: Member,
+    c111: VChar,
+):
+    """Transfer raises DuplicateCharacterError if the recipient has a same-named character."""
+    duplicate = gen_char("vampire")
+    duplicate.name = transform(c111.name)
+    duplicate.guild = g1.id
+    duplicate.user = u12.id
+    await mgrf.register(duplicate)
+
+    char = await mgrf.fetchid(c111.id_str)
+    assert char is not None
+
+    with patch(VCHAR_SAVE, new_callable=AsyncMock) as mock_save:
+        with pytest.raises(DuplicateCharacterError):
+            await mgrf.transfer(char, u11, u12)
+        mock_save.assert_not_awaited()
+
+    assert char.user == u11.id
+
+
+async def test_transfer_duplicate_name_other_guild_allowed(
+    mgrf: CharacterManager,
+    g2: Guild,
+    u11: Member,
+    u12: Member,
+    c111: VChar,
+):
+    """A same-named character in a different guild does not block a transfer."""
+    other_guild_char = gen_char("vampire")
+    other_guild_char.name = c111.name
+    other_guild_char.guild = g2.id
+    other_guild_char.user = u12.id
+    await mgrf.register(other_guild_char)
+
+    char = await mgrf.fetchid(c111.id_str)
+    assert char is not None
+    await mgrf.transfer(char, u11, u12)
+
+    assert char.user == u12.id
+
+
 async def test_exists(
     mgrf: CharacterManager,
     g1: Guild,

--- a/uv.lock
+++ b/uv.lock
@@ -533,7 +533,7 @@ wheels = [
 
 [[package]]
 name = "inconnu"
-version = "2026.6.0"
+version = "2026.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Fixes an issue whereby `/transfer` would allow duplicate character names.